### PR TITLE
packet length field is mal formed if length > 255

### DIFF
--- a/MQTTSNPacket/src/MQTTSNPacket.c
+++ b/MQTTSNPacket/src/MQTTSNPacket.c
@@ -66,7 +66,8 @@ int MQTTSNPacket_encode(unsigned char* buf, int length)
 	if (length > 255)
 	{
 		buf[rc++] = 0x01;
-		writeInt(&buf, length);
+		unsigned char *bufptr = &buf[rc];
+		writeInt(&bufptr, length);
 		rc += 2;
 	}
 	else

--- a/MQTTSNPacket/src/MQTTSNPacket.c
+++ b/MQTTSNPacket/src/MQTTSNPacket.c
@@ -65,10 +65,9 @@ int MQTTSNPacket_encode(unsigned char* buf, int length)
 	FUNC_ENTRY;
 	if (length > 255)
 	{
-		buf[rc++] = 0x01;
-		unsigned char *bufptr = &buf[rc];
-		writeInt(&bufptr, length);
-		rc += 2;
+		writeChar(&buf, 0x01);
+		writeInt(&buf, length);
+		rc += 3;
 	}
 	else
 		buf[rc++] = length;


### PR DESCRIPTION
Hello, 

If packet length is > 255 the first byte is overwritten by `writeInt(&buf, length);`

So here is a fix.