### PR TITLE
BugFix: Segmentation faultdue to incorrect ProtocolID of CONNECT. #53

### DIFF
--- a/MQTTSNPacket/src/MQTTSNConnectServer.c
+++ b/MQTTSNPacket/src/MQTTSNConnectServer.c
@@ -38,7 +38,7 @@ int MQTTSNDeserialize_connect(MQTTSNPacket_connectData* data, unsigned char* buf
 	int mylen = 0;
 
 	FUNC_ENTRY;
-	curdata += (rc = MQTTSNPacket_decode(curdata, len, &mylen)); /* read length */
+	curdata += MQTTSNPacket_decode(curdata, len, &mylen); /* read length */
 	enddata = buf + mylen;
 	if (enddata - curdata < 2)
 		goto exit;
@@ -50,7 +50,7 @@ int MQTTSNDeserialize_connect(MQTTSNPacket_connectData* data, unsigned char* buf
 	data->cleansession = flags.bits.cleanSession;
 	data->willFlag = flags.bits.will;
 
-	if ((version = (int)readChar(&curdata)) != 1) /* Protocol version */
+	if ((version = (int)readChar(&curdata)) != MQTTSN_PROTOCOL_VERSION)
 		goto exit;
 
 	data->duration = readInt(&curdata);


### PR DESCRIPTION
ProtocolID in CONNECT of MQTT-SN is defined in 5.3.8 ProtocolID as 0x01.
Segmentation fault occurs when other value is received.
Deserialize functions  in MQTTSNPacket skip to get all data when error occurs, and do not return a error code.
MQTTSNGWClientRecvTask::run() function does not handle this error code.

Signed-off-by: tomoaki <tomoaki@tomy-tech.com>