### PR TITLE
Bugfix of Gateway can't receive MQTT packets with no payload.

### DIFF
--- a/MQTTSNGateway/src/MQTTGWPacket.cpp
+++ b/MQTTSNGateway/src/MQTTGWPacket.cpp
@@ -204,23 +204,26 @@ int MQTTGWPacket::recv(Network* network)
 		multiplier *= 128;
 	} while ((c & 128) != 0);
 
-	/* allocate buffer */
-	_data = (unsigned char*)calloc(_remainingLength, 1);
-	if ( !_data )
+	if ( _remainingLength > 0 )
 	{
-		return -3;
-	}
+		/* allocate buffer */
+		_data = (unsigned char*)calloc(_remainingLength, 1);
+		if ( !_data )
+		{
+			return -3;
+		}
 
-	/* read Payload */
-	int remlen = network->recv(_data, _remainingLength);
+		/* read Payload */
+		int remlen = network->recv(_data, _remainingLength);
 
-	if (remlen == -1 )
-	{
-		return -1;
-	}
-	else if ( remlen != _remainingLength )
-	{
-		return -2;
+		if (remlen == -1 )
+		{
+			return -1;
+		}
+		else if ( remlen != _remainingLength )
+		{
+			return -2;
+		}
 	}
 	return 1 + len + _remainingLength;
 }

--- a/MQTTSNGateway/src/MQTTSNGWBrokerSendTask.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWBrokerSendTask.cpp
@@ -100,8 +100,8 @@ void BrokerSendTask::run()
 				if ( !rc )
 				{
 					/* disconnect the broker and the client */
-					WRITELOG("%s BrokerSendTask can't connect to the broker.  %s%s\n",
-							ERRMSG_HEADER, client->getClientId(), ERRMSG_FOOTER);
+					WRITELOG("%s BrokerSendTask: %s can't connect to the broker. errno=%d %s %s\n",
+							ERRMSG_HEADER, client->getClientId(), errno, strerror(errno), ERRMSG_FOOTER);
 					delete ev;
 					client->getNetwork()->close();
 					continue;
@@ -120,8 +120,8 @@ void BrokerSendTask::run()
 			}
 			else
 			{
-				WRITELOG("%s BrokerSendTask can't send a packet to the broker errno=%d %s%s\n",
-						ERRMSG_HEADER, rc == -1 ? errno : 0, client->getClientId(), ERRMSG_FOOTER);
+				WRITELOG("%s BrokerSendTask: %s can't send a packet to the broker. errno=%d %s %s\n",
+						ERRMSG_HEADER, client->getClientId(), rc == -1 ? errno : 0, strerror(errno), ERRMSG_FOOTER);
 				client->getNetwork()->close();
 
 				/* Disconnect the client */

--- a/MQTTSNGateway/src/linux/Network.cpp
+++ b/MQTTSNGateway/src/linux/Network.cpp
@@ -306,6 +306,7 @@ bool Network::connect(const char* host, const char* port, const char* caPath, co
 				throw false;
 			}
 
+
 			if (!SSL_CTX_load_verify_locations(_ctx, caFile, caPath))
 			{
 				ERR_error_string_n(ERR_get_error(), errmsg, sizeof(errmsg));


### PR DESCRIPTION
BufFix: Gateway can't receive MQTT packets with no payload.
Update:  Change a error message easy to understand.

Signed-off-by: tomoaki <tomoaki@tomy-tech.com>