### PR TITLE
Fixes for OpenWRT

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWPublishHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWPublishHandler.cpp
@@ -45,7 +45,7 @@ void MQTTSNPublishHandler::handlePublish(Client* client, MQTTSNPacket* packet)
 	Publish pub;
 	char  shortTopic[2];
 
-	if ( !client->isActive() )
+	if ( !client->isActive() && !client->isSleep())
 	{
 		/* Reply DISCONNECT to the client */
 		Event* ev = new Event();

--- a/MQTTSNGateway/src/linux/Network.cpp
+++ b/MQTTSNGateway/src/linux/Network.cpp
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
-#include <error.h>
 #include <regex>
 
 #include "Network.h"

--- a/MQTTSNGateway/src/linux/Timer.h
+++ b/MQTTSNGateway/src/linux/Timer.h
@@ -17,7 +17,7 @@
 #define MQTTSNGATEWAY_SRC_LINUX_TIMER_H_
 
 #include "MQTTSNGWDefines.h"
-#include <time.h>
+#include <sys/time.h>
 namespace MQTTSNGW
 {
 /*==========================================================


### PR DESCRIPTION
Signed-off-by: Ciupis, Jedrzej <jedrzej.ciupis@nordicsemi.no>

I've wanted to run MQTT-SN Gateway on Raspberry Pi. To do that, I had to cross-compile for OpenWRT. Two issues emerged:
1. struct timeval used in Timer.h is defined in <sys/time.h>, not <time.h>.
2. error.h seems to be obsolete and it generates error during cross-compilation.

Apart from that, there is an issue concerning sleepy nodes I would like to discuss.  The MQTT-SN protocol spec is unclear whether clients can publish messages when in asleep state. Since the protocol is designed to be as lightweight as possible, I think that connecting before every publish message is an unnecessary waste. In my opinion it would be better if gateway didn't forbid that operation, but rather left it to the client implementation. I have therefore changed the if condition in handlePublish() function so that it doesn't disconnect client publishing in asleep state.