### PR TITLE
Extended support of sleepy nodes

### DIFF
--- a/MQTTSNGateway/src/MQTTGWPublishHandler.cpp
+++ b/MQTTSNGateway/src/MQTTGWPublishHandler.cpp
@@ -136,7 +136,6 @@ void MQTTGWPublishHandler::handlePublish(Client* client, MQTTGWPacket* packet)
 	if (client->isSleep())
 	{
 		/* client is sleeping. save PUBLISH */
-		client->setClientSleepPacket(snPacket);
 		WRITELOG(FORMAT_Y_G_G, currentDateTime(), packet->getName(),
 		RIGHTARROW, client->getClientId(), "is sleeping. a message was saved.");
 		int type = 0;

--- a/MQTTSNGateway/src/MQTTSNGWClient.h
+++ b/MQTTSNGateway/src/MQTTSNGWClient.h
@@ -56,6 +56,7 @@ public:
 		{
 			_mutex.lock();
 			packet = _que->front();
+			_que->pop();
 			_mutex.unlock();
 			return packet;
 		}

--- a/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
@@ -260,6 +260,13 @@ void MQTTSNConnectionHandler::handleWillmsgupd(Client* client, MQTTSNPacket* pac
 void MQTTSNConnectionHandler::handlePingreq(Client* client, MQTTSNPacket* packet)
 {
 	/* send PINGREQ to the broker */
+	MQTTSNPacket* publish = new MQTTSNPacket();
+	while ((publish = client->getClientSleepPacket()) != 0)
+	{
+		Event* ev1 = new Event();
+		ev1->setClientSendEvent(client, publish);
+		_gateway->getClientSendQue()->post(ev1);
+	}
 	MQTTGWPacket* pingreq = new MQTTGWPacket();
 	pingreq->setHeader(PINGREQ);
 	Event* evt = new Event();


### PR DESCRIPTION
Signed-off-by: Ciupis, Jedrzej <jedrzej.ciupis@nordicsemi.no>

I have added publishing messages buffered for asleep clients as described in chapter 6.14 of MQTT-SN protocol spec. The gateway buffered the messages, but did not send them.