### PR TITLE
Bug Fix of Empty Client Id of CONNECT #86

### DIFF
--- a/MQTTSNGateway/GatewayTester/src/LGwProxy.h
+++ b/MQTTSNGateway/GatewayTester/src/LGwProxy.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "LMqttsnClientApp.h"
 #include "LNetworkUdp.h"
@@ -92,11 +93,11 @@ private:
 	uint8_t     _gwId;
 	uint16_t    _tkeepAlive;
 	uint32_t    _tAdv;
-	uint32_t    _sendUTC;
+	time_t      _sendUTC;
 	int         _retryCount;
 	int         _connectRetry;
 	uint8_t     _status;
-	uint32_t    _pingSendUTC;
+	time_t    _pingSendUTC;
 	uint8_t     _pingRetryCount;
 	uint8_t     _pingStatus;
 	LRegisterManager _regMgr;

--- a/MQTTSNGateway/GatewayTester/src/LPublishManager.h
+++ b/MQTTSNGateway/GatewayTester/src/LPublishManager.h
@@ -16,6 +16,7 @@
 #ifndef PUBLISHMANAGER_H_
 #define PUBLISHMANAGER_H_
 
+#include <time.h>
 #include "LMqttsnClientApp.h"
 #include "LTimer.h"
 #include "LTopicTable.h"
@@ -42,7 +43,7 @@ typedef struct PubElement{
     const char* topicName;
     uint8_t*  payload;
     uint16_t  payloadlen;
-    uint32_t  sendUTC;
+    time_t    sendUTC;
     int       (*callback)(void);
     int       retryCount;
     int       taskIndex;

--- a/MQTTSNGateway/GatewayTester/src/LRegisterManager.h
+++ b/MQTTSNGateway/GatewayTester/src/LRegisterManager.h
@@ -17,6 +17,7 @@
 #ifndef REGISTERQUE_H_
 #define REGISTERQUE_H_
 
+#include <time.h>
 #include "LMqttsnClientApp.h"
 
 namespace linuxAsyncClient {
@@ -27,7 +28,7 @@ typedef struct RegQueElement{
 	const char* topicName;
 	uint16_t msgId;
     int      retryCount;
-    uint32_t sendUTC;
+    time_t   sendUTC;
 	RegQueElement* prev;
 	RegQueElement* next;
 }RegQueElement;

--- a/MQTTSNGateway/GatewayTester/src/LSubscribeManager.h
+++ b/MQTTSNGateway/GatewayTester/src/LSubscribeManager.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "LMqttsnClientApp.h"
 #include "LRegisterManager.h"
@@ -33,7 +34,7 @@ typedef struct SubElement{
     TopicCallback callback;
     const char* topicName;
     uint16_t  msgId;
-    uint32_t  sendUTC;
+    time_t    sendUTC;
     uint16_t  topicId;
     uint8_t   msgType;
     uint8_t   topicType;

--- a/MQTTSNGateway/GatewayTester/src/LTaskManager.h
+++ b/MQTTSNGateway/GatewayTester/src/LTaskManager.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "LMqttsnClientApp.h"
 #include "LTimer.h"
@@ -29,8 +30,8 @@ namespace linuxAsyncClient {
 
 struct TaskList{
     void     (*callback)(void);
-	uint32_t interval;
-    uint32_t prevTime;
+	time_t   interval;
+    time_t    prevTime;
     uint8_t  count;
 };
 

--- a/MQTTSNGateway/GatewayTester/src/LTimer.cpp
+++ b/MQTTSNGateway/GatewayTester/src/LTimer.cpp
@@ -16,10 +16,12 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
+
 #include "LMqttsnClientApp.h"
 #include "LTimer.h"
 
-using namespace std;
+//using namespace std;
 using namespace linuxAsyncClient;
 
 /*=====================================

--- a/MQTTSNGateway/GatewayTester/src/LTimer.h
+++ b/MQTTSNGateway/GatewayTester/src/LTimer.h
@@ -17,7 +17,7 @@
 #ifndef TIMER_H_
 #define TIMER_H_
 
-#include <sys/time.h>
+#include <time.h>
 
 #include "LMqttsnClientApp.h"
 

--- a/MQTTSNGateway/src/MQTTGWPacket.cpp
+++ b/MQTTSNGateway/src/MQTTGWPacket.cpp
@@ -500,6 +500,7 @@ char* MQTTGWPacket::getMsgId(char* pbuf)
 	{
 	case PUBLISH:
 		Publish pub;
+		pub.msgId = 0;
 		getPUBLISH(&pub);
 		if ( _header.bits.dup )
 		{

--- a/MQTTSNGateway/src/MQTTSNGWClient.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWClient.cpp
@@ -227,6 +227,16 @@ Client* ClientList::createClient(SensorNetAddress* addr, MQTTSNString* clientId,
 	{
 		client->setClientId(*clientId);
 	}
+	else
+	{
+		MQTTSNString  dummyId;
+		char* id = (char*)malloc(1);
+		*id = 0;
+		dummyId.cstring = id;
+		dummyId.lenstring.len = 0;
+		client->setClientId(dummyId);
+		free(id);
+	}
 
 	/* add the list */
 	if ( _firstClient == 0 )


### PR DESCRIPTION
Set Client ID to a space cahr when the client ID of CONNECT is empty.

Signed-off-by: tomoaki <tomoaki@tomy-tech.com>