### PR TITLE
Improve UDPv6 code portability

### DIFF
--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -14,6 +14,7 @@
  * Contributors:
  *    Benjamin Aigner - Adaption of the UDPv4 code to use UDPv6
  *    Tomoaki Yamaguchi - initial API and implementation and/or initial documentation
+ *    Tieto Poland Sp. z o.o. - improve portability
  **************************************************************************************/
 #include <stdio.h>
 #include <unistd.h>
@@ -94,10 +95,10 @@ char* SensorNetAddress::getAddress(void)
 bool SensorNetAddress::isMatch(SensorNetAddress* addr)
 {
 	return ((this->_portNo == addr->_portNo) && \
-	(this->_IpAddr.sin6_addr.__in6_u.__u6_addr32[0] == addr->_IpAddr.sin6_addr.__in6_u.__u6_addr32[0]) && \
-	(this->_IpAddr.sin6_addr.__in6_u.__u6_addr32[1] == addr->_IpAddr.sin6_addr.__in6_u.__u6_addr32[1]) && \
-	(this->_IpAddr.sin6_addr.__in6_u.__u6_addr32[2] == addr->_IpAddr.sin6_addr.__in6_u.__u6_addr32[2]) && \
-	(this->_IpAddr.sin6_addr.__in6_u.__u6_addr32[3] == addr->_IpAddr.sin6_addr.__in6_u.__u6_addr32[3]));
+	(this->_IpAddr.sin6_addr.s6_addr32[0] == addr->_IpAddr.sin6_addr.s6_addr32[0]) && \
+	(this->_IpAddr.sin6_addr.s6_addr32[1] == addr->_IpAddr.sin6_addr.s6_addr32[1]) && \
+	(this->_IpAddr.sin6_addr.s6_addr32[2] == addr->_IpAddr.sin6_addr.s6_addr32[2]) && \
+	(this->_IpAddr.sin6_addr.s6_addr32[3] == addr->_IpAddr.sin6_addr.s6_addr32[3]));
 }
 
 SensorNetAddress& SensorNetAddress::operator =(SensorNetAddress& addr)


### PR DESCRIPTION
Hi,
It's safer to use `s6_addr32` macro than implementation specific union details.

Signed-off-by: Mariusz Suchora <mariusz.suchora@tieto.com>