### PR TITLE
Fix documentation of MQTTSNPacket_decode

### DIFF
--- a/MQTTSNPacket/src/MQTTSNPacket.c
+++ b/MQTTSNPacket/src/MQTTSNPacket.c
@@ -83,7 +83,8 @@ int MQTTSNPacket_encode(unsigned char* buf, int length)
 
 /**
  * Obtains the MQTT-SN packet length from received data
- * @param getcharfn pointer to function to read the next character from the data source
+ * @param buf the buffer that contains the MQTT-SN packet
+ * @param buflen the length in bytes of the supplied buffer
  * @param value the decoded length returned
  * @return the number of bytes read from the socket
  */


### PR DESCRIPTION
Added a documentation for the missing parameters buf and buflen and
removed the non-existing parameter getcharfn.

Signed-off-by: Martin Kirsche <martin.kirsche@gmail.com>