### PR TITLE
Support for MacOS

### DIFF
--- a/MQTTSNGateway/Makefile
+++ b/MQTTSNGateway/Makefile
@@ -77,6 +77,7 @@ $(SUBDIR)/MQTTSNUnsubscribeServer.c
 CXX := g++
 CPPFLAGS += 
 
+# include directories, for MacOS/homebrew add -I/usr/local/opt/openssl/include/
 INCLUDE :=
 INCLUDES += $(INCLUDE) -I$(SRCDIR) \
 -I$(SRCDIR)/$(OS) \
@@ -84,12 +85,16 @@ INCLUDES += $(INCLUDE) -I$(SRCDIR) \
 -I$(SUBDIR) \
 -I$(SRCDIR)/$(TEST)
 
+# preprocessor defines
 DEFS :=
+
+# library search paths, for MacOS/homebrew add -L/usr/local/opt/openssl/lib/
 LIB :=
 LIBS += $(LIB) -L/usr/local/lib
-LDFLAGS := 
+
+LDFLAGS :=
 CXXFLAGS := -Wall -O3 -std=c++11
-LDADD := -lpthread -lssl -lcrypto -lrt
+LDADD := -lpthread -lssl -lcrypto
 OUTDIR := Build
 
 PROG := $(OUTDIR)/$(PROGNAME)

--- a/MQTTSNGateway/src/MQTTSNGWProcess.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWProcess.cpp
@@ -103,7 +103,7 @@ void Process::initialize(int argc, char** argv)
 			}
 		}
 	}
-	_rbsem = new Semaphore(MQTTSNGW_RB_SEMAPHOR_NAME, 0);
+	_rbsem = new NamedSemaphore(MQTTSNGW_RB_SEMAPHOR_NAME, 0);
 	_rb = new RingBuffer(_configDir.c_str());
 
 	if (getParam("ShearedMemory", param) == 0)

--- a/MQTTSNGateway/src/MQTTSNGWProcess.h
+++ b/MQTTSNGateway/src/MQTTSNGWProcess.h
@@ -66,7 +66,7 @@ private:
 	string  _configDir;
 	string  _configFile;
 	RingBuffer* _rb;
-	Semaphore*  _rbsem;
+	NamedSemaphore*  _rbsem;
 	Mutex _mt;
 	int  _log;
 	char _rbdata[PROCESS_LOG_BUFFER_SIZE + 1];

--- a/MQTTSNGateway/src/linux/Network.cpp
+++ b/MQTTSNGateway/src/linux/Network.cpp
@@ -145,7 +145,11 @@ bool TCPStack::accept(TCPStack& new_socket)
 
 int TCPStack::send(const uint8_t* buf, int length)
 {
+#ifdef __APPLE__
+	return ::send(_sockfd, buf, length, SO_NOSIGPIPE);	
+#else
 	return ::send(_sockfd, buf, length, MSG_NOSIGNAL);
+#endif
 }
 
 int TCPStack::recv(uint8_t* buf, int len)

--- a/MQTTSNGateway/src/linux/Threading.cpp
+++ b/MQTTSNGateway/src/linux/Threading.cpp
@@ -21,27 +21,40 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
-#include <semaphore.h>
 #include <fcntl.h>
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <errno.h>
 
 using namespace std;
 using namespace MQTTSNGW;
 
-#if defined(OSX)
-int sem_timedwait(sem_type sem, const struct timespec *timeout)
+#ifdef __APPLE__
+
+int sem_timedwait(sem_t *sem, const struct timespec *abs_timeout)
 {
-	int rc = -1;
-	int64_t tout = timeout->tv_sec * 1000L + tv_nsec * 1000000L
-	rc = (int)dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, tout));
-	if (rc != 0)
+	while (true)
 	{
-		rc = ETIMEDOUT;
+		// try to lock the semaphore
+		int result = sem_trywait(sem);
+		if (result != -1 || errno != EAGAIN)
+			return result;
+
+		// spin lock
+		sched_yield();
+
+		// check if timeout reached
+		struct timespec ts;
+		clock_gettime(CLOCK_REALTIME, &ts);
+		if (ts.tv_sec > abs_timeout->tv_sec
+			|| (ts.tv_sec == abs_timeout->tv_sec && abs_timeout->tv_nsec >= ts.tv_nsec))
+		{
+			return ETIMEDOUT;
+		}
 	}
- 	return rc;
 }
+
 #endif
 
 /*=====================================
@@ -69,7 +82,7 @@ Mutex::Mutex(const char* fileName)
 		throw Exception( -1, "Mutex can't create a shared memory.");
 	}
 	_pmutex = (pthread_mutex_t*) shmat(_shmid, NULL, 0);
-	if (_pmutex < 0)
+	if (_pmutex == (void*) -1)
 	{
 		throw Exception( -1, "Mutex can't attach shared memory.");
 	}
@@ -153,21 +166,61 @@ void Mutex::unlock(void)
  Class Semaphore
  =====================================*/
 
-Semaphore::Semaphore()
-{
-	sem_init(&_sem, 0, 0);
-	_name = 0;
-	_psem = 0;
-}
-
 Semaphore::Semaphore(unsigned int val)
 {
+#ifdef __APPLE__
+	_sem = dispatch_semaphore_create(val);
+#else
 	sem_init(&_sem, 0, val);
-	_name = 0;
-	_psem = 0;
+#endif
 }
 
-Semaphore::Semaphore(const char* name, unsigned int val)
+Semaphore::~Semaphore()
+{
+#ifdef __APPLE__
+	dispatch_release(_sem);
+#else
+	sem_destroy(&_sem);
+#endif
+}
+
+void Semaphore::post(void)
+{
+#ifdef __APPLE__
+	dispatch_semaphore_signal(_sem);
+#else
+	sem_post(&_sem);
+#endif
+}
+
+void Semaphore::wait(void)
+{
+#ifdef __APPLE__
+	dispatch_semaphore_wait(_sem, DISPATCH_TIME_FOREVER);
+#else
+	sem_wait(&_sem);
+#endif
+}
+
+void Semaphore::timedwait(uint16_t millsec)
+{
+#ifdef __APPLE__
+	dispatch_semaphore_wait(_sem, dispatch_time(DISPATCH_TIME_NOW, int64_t(millsec) * 1000000));
+#else
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	int nsec = ts.tv_nsec + (millsec % 1000) * 1000000;
+	ts.tv_nsec = nsec % 1000000000;
+	ts.tv_sec += millsec / 1000 + nsec / 1000000000;
+	sem_timedwait(&_sem, &ts);
+#endif
+}
+
+/*=====================================
+ Class NamedSemaphore
+ =====================================*/
+
+NamedSemaphore::NamedSemaphore(const char* name, unsigned int val)
 {
 	_psem = sem_open(name, O_CREAT, 0666, val);
 	if (_psem == SEM_FAILED)
@@ -181,67 +234,30 @@ Semaphore::Semaphore(const char* name, unsigned int val)
 	}
 }
 
-Semaphore::~Semaphore()
+NamedSemaphore::~NamedSemaphore()
 {
-	if (_name)
-	{
-		sem_close(_psem);
-		sem_unlink(_name);
-		free(_name);
-	}
-	else
-	{
-		sem_destroy(&_sem);
-	}
+	sem_close(_psem);
+	sem_unlink(_name);
+	free(_name);
 }
 
-void Semaphore::post(void)
+void NamedSemaphore::post(void)
 {
-	int val = 0;
-	if (_psem)
-	{
-		sem_getvalue(_psem, &val);
-		if (val <= 0)
-		{
-			sem_post(_psem);
-		}
-	}
-	else
-	{
-		sem_getvalue(&_sem, &val);
-		if (val <= 0)
-		{
-			sem_post(&_sem);
-		}
-	}
+	sem_post(_psem);
 }
 
-void Semaphore::wait(void)
+void NamedSemaphore::wait(void)
 {
-	if (_psem)
-	{
-		sem_wait(_psem);
-	}
-	else
-	{
-		sem_wait(&_sem);
-	}
+	sem_wait(_psem);
 }
 
-void Semaphore::timedwait(uint16_t millsec)
+void NamedSemaphore::timedwait(uint16_t millsec)
 {
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	ts.tv_sec += millsec / 1000;
 	ts.tv_nsec = (millsec % 1000) * 1000000;
-	if (_psem)
-	{
-		sem_timedwait(_psem, &ts);
-	}
-	else
-	{
-		sem_timedwait(&_sem, &ts);
-	}
+	sem_timedwait(_psem, &ts);
 }
 
 /*=========================================
@@ -274,7 +290,7 @@ RingBuffer::RingBuffer(const char* keyDirectory)
 	if ((_shmid = shmget(key, PROCESS_LOG_BUFFER_SIZE,
 	IPC_CREAT | IPC_EXCL | 0666)) >= 0)
 	{
-		if ((_shmaddr = (uint16_t*) shmat(_shmid, NULL, 0)) > 0)
+		if ((_shmaddr = (uint16_t*) shmat(_shmid, NULL, 0)) != (void*) -1)
 		{
 			_length = (uint16_t*) _shmaddr;
 			_start = (uint16_t*) _length + sizeof(uint16_t*);
@@ -290,9 +306,9 @@ RingBuffer::RingBuffer(const char* keyDirectory)
 			throw Exception(-1, "RingBuffer can't attach shared memory.");
 		}
 	}
-	else if ((_shmid = shmget(key, PROCESS_LOG_BUFFER_SIZE, IPC_CREAT | 0666)) >= 0)
+	else if ((_shmid = shmget(key, PROCESS_LOG_BUFFER_SIZE, IPC_CREAT | 0666)) != -1)
 	{
-		if ((_shmaddr = (uint16_t*) shmat(_shmid, NULL, 0)) > 0)
+		if ((_shmaddr = (uint16_t*) shmat(_shmid, NULL, 0)) != (void*) -1)
 		{
 			_length = (uint16_t*) _shmaddr;
 			_start = (uint16_t*) _length + sizeof(uint16_t*);
@@ -330,7 +346,7 @@ RingBuffer::~RingBuffer()
 		}
 	}
 
-	if (_pmx > 0)
+	if (_pmx != NULL)
 	{
 		delete _pmx;
 	}

--- a/MQTTSNGateway/src/linux/Threading.h
+++ b/MQTTSNGateway/src/linux/Threading.h
@@ -19,6 +19,9 @@
 
 #include <pthread.h>
 #include <semaphore.h>
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+#endif
 #include "MQTTSNGWDefines.h"
 
 namespace MQTTSNGW
@@ -52,17 +55,34 @@ private:
 class Semaphore
 {
 public:
-	Semaphore();
-	Semaphore(unsigned int val);
-	Semaphore(const char* name, unsigned int val);
+	Semaphore(unsigned int val = 0);
 	~Semaphore();
 	void post(void);
 	void wait(void);
 	void timedwait(uint16_t millsec);
 
 private:
+#ifdef __APPLE__
+	dispatch_semaphore_t _sem;
+#else
+	sem_t _sem;
+#endif
+};
+
+/*=====================================
+         Class NamedSemaphore
+  ====================================*/
+class NamedSemaphore
+{
+public:
+	NamedSemaphore(const char* name, unsigned int val);
+	~NamedSemaphore();
+	void post(void);
+	void wait(void);
+	void timedwait(uint16_t millsec);
+
+private:
 	sem_t* _psem;
-	sem_t  _sem;
 	char*  _name;
 };
 

--- a/MQTTSNPacket/src/MQTTSNSearchClient.c
+++ b/MQTTSNPacket/src/MQTTSNSearchClient.c
@@ -116,7 +116,7 @@ int MQTTSNDeserialize_gwinfo(unsigned char* gatewayid, unsigned short* gatewayad
 	*gatewayid = readChar(&curdata);
 
 	*gatewayaddress_len = enddata - curdata;
-	*gatewayaddress = (gatewayaddress_len > 0) ? curdata : NULL;
+	*gatewayaddress = (*gatewayaddress_len > 0) ? curdata : NULL;
 
 	rc = 1;
 exit:


### PR DESCRIPTION
Got it to compile on MacOS. I had to split semaphore into Semaphore and NamedSemaphore classes like in boost. Semaphore is implemented with Grand Central Dispatch because sem_init returns not implemented error MacOS. NamedSemaphore uses the spin lock approach like in boost for sem_timedwait. sem_getvalue is also not supported on MacOS so I had to remove it, this is the only possible source of problems in this patch.

Note the change in MQTTSNSearchClient.c, there seems to be a bug: (gatewayaddress_len > 0) is always true, I assume it must be (*gatewayaddress_len > 0)