### PR TITLE
Fix bug for messages of length 0x100

### DIFF
--- a/MQTTSNPacket/src/MQTTSNPacket.c
+++ b/MQTTSNPacket/src/MQTTSNPacket.c
@@ -53,7 +53,7 @@ const char* MQTTSNPacket_name(int code)
  */
 int MQTTSNPacket_len(int length)
 {
-	return (length > 255) ? length + 3 : length + 1;
+	return (length > 254) ? length + 3 : length + 1;
 }
 
 /**


### PR DESCRIPTION
If the parameter `length` is 255 bytes the result of the previous `MQTTSNPacket_len` implementation was 256 bytes. But such a message actually needs a 3-octet long Length field, so it should return 258 instead.

Signed-off-by: Martin Kirsche <martin.kirsche@gmail.com>