### PR TITLE
Update MQTTSNPacket.c

### DIFF
--- a/MQTTSNPacket/src/MQTTSNPacket.c
+++ b/MQTTSNPacket/src/MQTTSNPacket.c
@@ -53,7 +53,7 @@ const char* MQTTSNPacket_name(int code)
  */
 int MQTTSNPacket_len(int length)
 {
-	return (length > 255) ? length + 3 : length + 1;
+	return (length >= 255) ? length + 3 : length + 1;
 }
 
 /**


### PR DESCRIPTION
Looks like a bug in MQTTSNPacket_len(). If the input parameter is 255, it will return 256, but the actual packet size will be 258.