### PR TITLE
[MQTTSNGateway] Bug fixes

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
@@ -104,10 +104,14 @@ void MQTTSNConnectionHandler::handleConnect(Client* client, MQTTSNPacket* packet
 	connectData->keepAliveTimer = data.duration;
 	connectData->flags.bits.will = data.willFlag;
 
-	if ((const char*) _gateway->getGWParams()->loginId != nullptr && (const char*) _gateway->getGWParams()->password != 0)
+	if ((const char*) _gateway->getGWParams()->loginId != nullptr)
+	{
+		connectData->flags.bits.username = 1;
+	}
+
+	if ((const char*) _gateway->getGWParams()->password != 0)
 	{
 		connectData->flags.bits.password = 1;
-		connectData->flags.bits.username = 1;
 	}
 
 	client->setSessionStatus(false);

--- a/MQTTSNGateway/src/linux/Network.cpp
+++ b/MQTTSNGateway/src/linux/Network.cpp
@@ -528,6 +528,7 @@ loop:
 			break;
 		case SSL_ERROR_ZERO_RETURN:
 			SSL_shutdown(_ssl);
+			SSL_free(_ssl);
 			_ssl = 0;
 			_numOfInstance--;
 			//TCPStack::close();
@@ -540,6 +541,15 @@ loop:
 			break;
 		case SSL_ERROR_WANT_WRITE:
 			readBlockedOnWrite = true;
+			break;
+		case SSL_ERROR_SYSCALL:
+			SSL_free(_ssl);
+			_ssl = 0;
+			_numOfInstance--;
+			//TCPStack::close();
+			_busy = false;
+			_mutex.unlock();
+			return -1;
 			break;
 		default:
 			ERR_error_string_n(ERR_get_error(), errmsg, sizeof(errmsg));


### PR DESCRIPTION
Changes:
1. Support MQTT connect with only login provided. Eg. When connecting to
Azure IoTHub with cert base auth, you only require login.
2. Proper cleanup of ssl context when server disconnects and client
does read on that ssl session. SSL_read api in this case causes
SSL_ERROR_SYSCALL.

Testing:

All gateway test passes with following message:
                                                                                                                                                                                                                                                                                        **** Step11:Disconnect complete ****                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            #########  All tests complete!  ###########   
