### PR TITLE
Send DISCONNECT when incoming message can't be mapped to a client

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWClientRecvTask.cpp
@@ -228,7 +228,11 @@ void ClientRecvTask::run()
 				}
 				else
 				{
-					WRITELOG("%s MQTTSNGWClientRecvTask  Client(%s) is not connecting. message has been discarded.%s\n", ERRMSG_HEADER, senderAddr->sprint(buf), ERRMSG_FOOTER);
+					WRITELOG("%s MQTTSNGWClientRecvTask  Client(%s) is not connected. message has been discarded.%s\n", ERRMSG_HEADER, senderAddr->sprint(buf), ERRMSG_FOOTER);MQTTSNPacket* snPacket = new MQTTSNPacket();
+					snPacket->setDISCONNECT(0);
+					Event* ev1 = new Event();
+					ev1->setClientSendEvent(senderAddr, snPacket);
+					_gateway->getClientSendQue()->post(ev1);
 				}
 				delete packet;
 			}

--- a/MQTTSNGateway/src/MQTTSNGateway.cpp
+++ b/MQTTSNGateway/src/MQTTSNGateway.cpp
@@ -494,11 +494,6 @@ Event::Event()
 
 Event::~Event()
 {
-	if (_sensorNetAddr)
-	{
-		delete _sensorNetAddr;
-	}
-
 	if (_mqttSNPacket)
 	{
 		delete _mqttSNPacket;


### PR DESCRIPTION
The MQTT-SN spec (v1.2, p. 17) states:

> A server or gateway may also sends a DISCONNECT to a client, e.g. in case a gateway, due to an error, cannot map a received message to a client. Upon receiving such a DISCONNECT message, a client should try to setup the connection again by sending a CONNECT message to the gateway or server. In all these cases the DISCONNECT message does not contain the Duration field.

Currently, the gateway only prints an error message but does not react in any other way to incoming messages (e.g. SUBSCRIBE, PUBLISH) that it can't map to a client. For example, this is the case when the client's IP address has changed since the connection was established. Since the client expects a response from the gateway, this leads to the client retransmitting the request and finally timing out (p. 25):

> After N_{retry} retransmissions, the client aborts the procedure and assumes that its MQTT-SN connection to the
gateway is disconnected. It should then try to connect to another gateway, and only if it fails to re-connect again
to the former gateway.

With this change, the gateway sends a DISCONNECT message to the unknown client. The client is then able to re-CONNECT with the new IP address.

(I have not signed the ECA yet. if this is something that could be merged, I will try to get that done.)