### PR TITLE
Fix165

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
@@ -281,16 +281,13 @@ void MQTTSNConnectionHandler::handlePingreq(Client* client, MQTTSNPacket* packet
 	    sendStoredPublish(client);
 		client->holdPingRequest();
 	}
-	// else
-	{
-        /* send PINGREQ to the broker */
-	    client->resetPingRequest();
-        MQTTGWPacket* pingreq = new MQTTGWPacket();
-        pingreq->setHeader(PINGREQ);
-        Event* evt = new Event();
-        evt->setBrokerSendEvent(client, pingreq);
-        _gateway->getBrokerSendQue()->post(evt);
-	}
+	/* send PINGREQ to the broker */
+	client->resetPingRequest();
+	MQTTGWPacket* pingreq = new MQTTGWPacket();
+	pingreq->setHeader(PINGREQ);
+	Event* evt = new Event();
+	evt->setBrokerSendEvent(client, pingreq);
+	_gateway->getBrokerSendQue()->post(evt);
 }
 
 void MQTTSNConnectionHandler::sendStoredPublish(Client* client)

--- a/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
@@ -281,7 +281,7 @@ void MQTTSNConnectionHandler::handlePingreq(Client* client, MQTTSNPacket* packet
 	    sendStoredPublish(client);
 		client->holdPingRequest();
 	}
-	else
+	// else
 	{
         /* send PINGREQ to the broker */
 	    client->resetPingRequest();


### PR DESCRIPTION
d91de457 accidentally got rid of the fix from 7aa44d94.

More info here. 

https://github.com/eclipse/paho.mqtt-sn.embedded-c/commit/7aa44d94d1125074935a523303fe6f46eef70e14

The current state of both develop and master are back to the bug described in the link above. I just tested it and this fixes that behavior. 

Before:

client wakes -> has a waiting message -> sends a pingreq -> the gateway responds with the waiting message

Now:

client wakes -> has a waiting message -> sends a pingreq -> the gateway responds with the waiting message ->gateway sends pingresp