### PR TITLE
Add bug 165 fix back in

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWConnectionHandler.cpp
@@ -281,16 +281,13 @@ void MQTTSNConnectionHandler::handlePingreq(Client* client, MQTTSNPacket* packet
 	    sendStoredPublish(client);
 		client->holdPingRequest();
 	}
-	else
-	{
-        /* send PINGREQ to the broker */
-	    client->resetPingRequest();
-        MQTTGWPacket* pingreq = new MQTTGWPacket();
-        pingreq->setHeader(PINGREQ);
-        Event* evt = new Event();
-        evt->setBrokerSendEvent(client, pingreq);
-        _gateway->getBrokerSendQue()->post(evt);
-	}
+	/* send PINGREQ to the broker */
+	client->resetPingRequest();
+	MQTTGWPacket* pingreq = new MQTTGWPacket();
+	pingreq->setHeader(PINGREQ);
+	Event* evt = new Event();
+	evt->setBrokerSendEvent(client, pingreq);
+	_gateway->getBrokerSendQue()->post(evt);
 }
 
 void MQTTSNConnectionHandler::sendStoredPublish(Client* client)


### PR DESCRIPTION
Signed-off-by: MBakerParagon <mbaker@paragoninnovations.com>

d91de45 accidentally got rid of the fix from 7aa44d9.

More info here.

7aa44d9

The current state of both develop and master are back to the bug described in the link above. I just tested it and this fixes that behavior.

Before:

client wakes -> has a waiting message -> sends a pingreq -> the gateway responds with the waiting message

Now:

client wakes -> has a waiting message -> sends a pingreq -> the gateway responds with the waiting message ->gateway sends pingresp