### PR TITLE
Bugfix: MQTTSNGateway mangles UDP6 client list

### DIFF
--- a/MQTTSNGateway/gateway.conf
+++ b/MQTTSNGateway/gateway.conf
@@ -35,7 +35,7 @@ PredefinedTopic=NO
 
 #RootCAfile=/etc/ssl/certs/ca-certificates.crt
 #RootCApath=/etc/ssl/certs/
-#CertsFile=/path/to/certKey.pem
+#CertKey=/path/to/certKey.pem
 #PrivateKey=/path/to/privateKey.pem
 
 GatewayID=1

--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -83,7 +83,7 @@ int SensorNetAddress::setAddress(string* data)
 		{
 			_portNo = htons(portNo);
 
-			string ip = data->substr(1,pos - 1);
+			string ip = data->substr(0,pos);
 			const char *cstr = ip.c_str();
 
 			if (inet_pton(AF_INET6, cstr, &(_IpAddr.sin6_addr)) == 1 )


### PR DESCRIPTION
Fixes an off-by-one-error in the code that parses the IP6 address of the client list when SENSORNET=udp6.

See SENSORNET=udp which has the same logic. (Tested on Raspberry PI)