### PR TITLE
fix: secure client networks no longer work with pre-allocated client list

### DIFF
--- a/MQTTSNGateway/src/MQTTSNGWClient.cpp
+++ b/MQTTSNGateway/src/MQTTSNGWClient.cpp
@@ -34,7 +34,7 @@ char* currentDateTime(void);
 static const char* theClientStatus[] = { "InPool", "Disconnected", "TryConnecting", "Connecting", "Active", "Asleep", "Awake",
         "Lost" };
 
-Client::Client(bool secure)
+Client::Client()
 {
     _packetId = 0;
     _snMsgId = 0;
@@ -45,8 +45,7 @@ Client::Client(bool secure)
     _willTopic = nullptr;
     _willMsg = nullptr;
     _connectData = MQTTPacket_Connect_Initializer;
-    _network = new Network(secure);
-    _secureNetwork = secure;
+    _network = new Network();
     _sensorNetype = true;
     _connAck = nullptr;
     _waitWillMsgFlg = false;
@@ -426,7 +425,7 @@ bool Client::isConnecting(void)
 
 bool Client::isSecureNetwork(void)
 {
-    return _secureNetwork;
+    return _network->isSecure();
 }
 
 bool Client::isSensorNetStable(void)

--- a/MQTTSNGateway/src/MQTTSNGWClient.h
+++ b/MQTTSNGateway/src/MQTTSNGWClient.h
@@ -179,8 +179,7 @@ class Client
     friend class ClientList;
     friend class ClientsPool;
 public:
-    Client(bool secure = false);
-    Client(uint8_t maxInflightMessages, bool secure);
+    Client();
     ~Client();
 
     Connect* getConnectData(void);

--- a/MQTTSNGateway/src/linux/Network.cpp
+++ b/MQTTSNGateway/src/linux/Network.cpp
@@ -238,11 +238,11 @@ int Network::_numOfInstance = 0;
 SSL_CTX* Network::_ctx = 0;
 SSL_SESSION* Network::_session = 0;
 
-Network::Network(bool secure) :
+Network::Network() :
 		TCPStack()
 {
 	_ssl = 0;
-	_secureFlg = secure;
+	_secureFlg = false;
 	_busy = false;
 	_sslValid = false;
 }

--- a/MQTTSNGateway/src/linux/Network.h
+++ b/MQTTSNGateway/src/linux/Network.h
@@ -68,7 +68,7 @@ private:
 class Network: public TCPStack
 {
 public:
-	Network(bool secure);
+	Network();
 	virtual ~Network();
 
 	bool connect(const char* host, const char* port, const char* caPath, const char* caFile, const char* cert, const char* prvkey);


### PR DESCRIPTION
The pre-allocated client list instantiated clients w/o setting the secure flag correctly. Only the network's secure flag was set from the clients configuration file.

This patch also eliminates redundancy by keeping the secure flag in a single place.