### PR TITLE
fix: the sample configuration contains a non-existent configuration key

### DIFF
--- a/MQTTSNGateway/README.md
+++ b/MQTTSNGateway/README.md
@@ -69,17 +69,17 @@ BrokerSecurePortNo=8883
 **BrokerSecurePortNo** is a broker's port no of TLS connection.    
 ```
 #
-# CertsKey for TLS connections to a broker
+# CertKey for TLS connections to a broker
 #
 
 #RootCAfile=/etc/ssl/certs/ca-certificates.crt
 #RootCApath=/etc/ssl/certs/
-#CertsKey=/path/to/certKey.pem
+#CertKey=/path/to/certKey.pem
 #PrivateKey=/path/to/privateKey.pem
 ```
 **RootCAfile** is a CA file name.    
 **RootCApath** is a CA path. **SSL_CTX_load_verify_locations(ctx, CAfile, CApath)** function requires these parameters.        
-**CertsKey** is a certificate pem file.    
+**CertKey** is a certificate pem file.
 **PrivateKey** is a private key pem file.   
 Clients can connect to the broker via TLS by setting '**Secure Connection**' for each client in the client conf file.   
 ```

--- a/MQTTSNGateway/gateway.conf
+++ b/MQTTSNGateway/gateway.conf
@@ -31,7 +31,7 @@ BrokerSecurePortNo=8883
 
 #RootCAfile=/etc/ssl/certs/ca-certificates.crt
 #RootCApath=/etc/ssl/certs/
-#CertsKey=/path/to/certKey.pem
+#CertKey=/path/to/certKey.pem
 #PrivateKey=/path/to/privateKey.pem
 
 #


### PR DESCRIPTION
The sample configuration contains a configuration key for the certificate key that does not exist in the application code.

Rather than breaking backwards compatibility of the configuration by updating the code (which would be more consistent wrt DTLS) I propse that the sample configuration is being aligned with what the code actually expects.