### PR TITLE
Process IPv6 scope id

### DIFF
--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -59,6 +59,11 @@ uint16_t SensorNetAddress::getPortNo(void)
     return _IpAddr.sin6_port;
 }
 
+uint32_t SensorNetAddress::getScopeId(void)
+{
+    return _IpAddr.sin6_scope_id;
+}
+
 void SensorNetAddress::setAddress(struct sockaddr_in6 *IpAddr)
 {
     memcpy((void*) &_IpAddr, IpAddr, sizeof(_IpAddr));
@@ -397,6 +402,7 @@ int UDPPort6::unicast(const uint8_t* buf, uint32_t length, SensorNetAddress* add
     memset(&dest, 0, sizeof(dest));
     dest.sin6_family = AF_INET6;
     dest.sin6_port = addr->getPortNo();
+    dest.sin6_scope_id = addr->getScopeId();
     memcpy(dest.sin6_addr.s6_addr, (const void*) &addr->getIpAddress()->sin6_addr, sizeof(in6_addr));
 
 #ifdef  DEBUG_NW

--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.h
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.h
@@ -42,6 +42,7 @@ public:
     int  setAddress(const char* data);
     uint16_t getPortNo(void);
     sockaddr_in6* getIpAddress(void);
+    uint32_t getScopeId(void);
     char* getAddress(void);
     bool isMatch(SensorNetAddress* addr);
     SensorNetAddress& operator =(SensorNetAddress& addr);


### PR DESCRIPTION
Send data to the same interface we originally received from. This allows the use of TAP devices for communication.