### PR TITLE
code-style fix: suggestion using 4 space standard

### DIFF
--- a/MQTTSNPacket/samples/linux/rfcomm/pub0sub1.c
+++ b/MQTTSNPacket/samples/linux/rfcomm/pub0sub1.c
@@ -29,27 +29,27 @@
 
 int main(int argc, char** argv)
 {
-	int rc = 0;
-	unsigned char buf[200];
-	int buflen = sizeof(buf);
-	MQTTSN_topicid topic;
-	unsigned char* payload = (unsigned char*)"mypayload";
-	int payloadlen = strlen((char*)payload);
-	int len = 0;
-	unsigned char dup = 0;
-	int qos = 1;
-	unsigned char retained = 0;
-	short packetid = 1;
-	char *topicname = "a long topic name";
+    int rc = 0;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    MQTTSN_topicid topic;
+    unsigned char* payload = (unsigned char*)"mypayload";
+    int payloadlen = strlen((char*)payload);
+    int len = 0;
+    unsigned char dup = 0;
+    int qos = 1;
+    unsigned char retained = 0;
+    short packetid = 1;
+    char *topicname = "a long topic name";
     char *host = "";
     int channel = 1;
-	MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
-	unsigned short topicid;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+    unsigned short topicid;
 
-	if (argc > 1)
-		host = argv[1];
+    if (argc > 1)
+        host = argv[1];
 
-	if (argc > 2)
+    if (argc > 2)
         channel = atoi(argv[2]);
 
     printf("Sending to address %s channel %d\n", host, channel);
@@ -58,107 +58,107 @@ int main(int argc, char** argv)
         goto exit;
     }
 
-	options.clientID.cstring = "pub0sub1 MQTT-SN";
-	len = MQTTSNSerialize_connect(buf, buflen, &options);
+    options.clientID.cstring = "pub0sub1 MQTT-SN";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
-	/* wait for connack */
+    /* wait for connack */
     if (MQTTSNPacket_read(buf, buflen, rfcomm_getdata) == MQTTSN_CONNACK)
-	{
-		int connack_rc = -1;
+    {
+        int connack_rc = -1;
 
-		if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
-		{
-			printf("Unable to connect, return code %d\n", connack_rc);
-			goto exit;
-		}
-		else 
-			printf("connected rc %d\n", connack_rc);
-	}
-	else
-		goto exit;
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            printf("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else 
+            printf("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
 
 
-	/* subscribe */
-	printf("Subscribing\n");
-	topic.type = MQTTSN_TOPIC_TYPE_NORMAL;
-	topic.data.long_.name = topicname;
-	topic.data.long_.len = strlen(topic.data.long_.name);
-	len = MQTTSNSerialize_subscribe(buf, buflen, 0, 2, packetid, &topic);
+    /* subscribe */
+    printf("Subscribing\n");
+    topic.type = MQTTSN_TOPIC_TYPE_NORMAL;
+    topic.data.long_.name = topicname;
+    topic.data.long_.len = strlen(topic.data.long_.name);
+    len = MQTTSNSerialize_subscribe(buf, buflen, 0, 2, packetid, &topic);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
     if (MQTTSNPacket_read(buf, buflen, rfcomm_getdata) == MQTTSN_SUBACK) /* wait for suback */
-	{
-		unsigned short submsgid;
-		int granted_qos;
-		unsigned char returncode;
+    {
+        unsigned short submsgid;
+        int granted_qos;
+        unsigned char returncode;
 
-		rc = MQTTSNDeserialize_suback(&granted_qos, &topicid, &submsgid, &returncode, buf, buflen);
-		if (granted_qos != 2 || returncode != 0)
-		{
-			printf("granted qos != 2, %d return code %d\n", granted_qos, returncode);
-			goto exit;
-		}
-		else
-			printf("suback topic id %d\n", topicid);
-	}
-	else
-		goto exit;
+        rc = MQTTSNDeserialize_suback(&granted_qos, &topicid, &submsgid, &returncode, buf, buflen);
+        if (granted_qos != 2 || returncode != 0)
+        {
+            printf("granted qos != 2, %d return code %d\n", granted_qos, returncode);
+            goto exit;
+        }
+        else
+            printf("suback topic id %d\n", topicid);
+    }
+    else
+        goto exit;
 
-	printf("Publishing\n");
-	/* publish with short name */
-	topic.type = MQTTSN_TOPIC_TYPE_NORMAL;
-	topic.data.id = topicid;
-	++packetid;
-	len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
-			topic, payload, payloadlen);
+    printf("Publishing\n");
+    /* publish with short name */
+    topic.type = MQTTSN_TOPIC_TYPE_NORMAL;
+    topic.data.id = topicid;
+    ++packetid;
+    len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
+            topic, payload, payloadlen);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
-	/* wait for puback */
+    /* wait for puback */
     if (MQTTSNPacket_read(buf, buflen, rfcomm_getdata) == MQTTSN_PUBACK)
-	{
-		unsigned short packet_id, topic_id;
-		unsigned char returncode;
+    {
+        unsigned short packet_id, topic_id;
+        unsigned char returncode;
 
-		if (MQTTSNDeserialize_puback(&topic_id, &packet_id, &returncode, buf, buflen) != 1 || returncode != MQTTSN_RC_ACCEPTED)
-			printf("Unable to publish, return code %d\n", returncode);
-		else 
-			printf("puback received, msgid %d topic id %d\n", packet_id, topic_id);
-	}
-	else
-		goto exit;
+        if (MQTTSNDeserialize_puback(&topic_id, &packet_id, &returncode, buf, buflen) != 1 || returncode != MQTTSN_RC_ACCEPTED)
+            printf("Unable to publish, return code %d\n", returncode);
+        else 
+            printf("puback received, msgid %d topic id %d\n", packet_id, topic_id);
+    }
+    else
+        goto exit;
 
-	printf("Receive publish\n");
+    printf("Receive publish\n");
     if (MQTTSNPacket_read(buf, buflen, rfcomm_getdata) == MQTTSN_PUBLISH)
-	{
-		unsigned short packet_id;
-		int qos, payloadlen;
-		unsigned char* payload;
-		unsigned char dup, retained;
-		MQTTSN_topicid pubtopic;
+    {
+        unsigned short packet_id;
+        int qos, payloadlen;
+        unsigned char* payload;
+        unsigned char dup, retained;
+        MQTTSN_topicid pubtopic;
 
-		if (MQTTSNDeserialize_publish(&dup, &qos, &retained, &packet_id, &pubtopic,
-				&payload, &payloadlen, buf, buflen) != 1)
-			printf("Error deserializing publish\n");
-		else 
-			printf("publish received, id %d qos %d\n", packet_id, qos);
+        if (MQTTSNDeserialize_publish(&dup, &qos, &retained, &packet_id, &pubtopic,
+                &payload, &payloadlen, buf, buflen) != 1)
+            printf("Error deserializing publish\n");
+        else 
+            printf("publish received, id %d qos %d\n", packet_id, qos);
 
-		if (qos == 1)
-		{
-			len = MQTTSNSerialize_puback(buf, buflen, pubtopic.data.id, packet_id, MQTTSN_RC_ACCEPTED);
+        if (qos == 1)
+        {
+            len = MQTTSNSerialize_puback(buf, buflen, pubtopic.data.id, packet_id, MQTTSN_RC_ACCEPTED);
             rc = rfcomm_sendPacketBuffer(buf, len);
-			if (rc == 0)
-				printf("puback sent\n");
-		}
-	}
-	else
-		goto exit;
+            if (rc == 0)
+                printf("puback sent\n");
+        }
+    }
+    else
+        goto exit;
 
-	len = MQTTSNSerialize_disconnect(buf, buflen, 0);
+    len = MQTTSNSerialize_disconnect(buf, buflen, 0);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
 exit:
-	rfcomm_close();
+    rfcomm_close();
 
-	return 0;
+    return 0;
 }

--- a/MQTTSNPacket/samples/linux/rfcomm/qos0pub.c
+++ b/MQTTSNPacket/samples/linux/rfcomm/qos0pub.c
@@ -28,26 +28,26 @@
 
 int main(int argc, char** argv)
 {
-	int rc = 0;
-	unsigned char buf[200];
-	int buflen = sizeof(buf);
-	MQTTSN_topicid topic;
-	unsigned char* payload = (unsigned char*)"mypayload";
-	int payloadlen = strlen((char*)payload);
-	int len = 0;
-	int dup = 0;
-	int qos = 0;
-	int retained = 0;
-	short packetid = 0;
-//	char *topicname = "a long topic name";
+    int rc = 0;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    MQTTSN_topicid topic;
+    unsigned char* payload = (unsigned char*)"mypayload";
+    int payloadlen = strlen((char*)payload);
+    int len = 0;
+    int dup = 0;
+    int qos = 0;
+    int retained = 0;
+    short packetid = 0;
+//  char *topicname = "a long topic name";
     char *host = "";
     int channel = 1;
-	MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
 
-	if (argc > 1)
-		host = argv[1];
+    if (argc > 1)
+        host = argv[1];
 
-	if (argc > 2)
+    if (argc > 2)
         channel = atoi(argv[2]);
 
     printf("Sending to address %s port %d\n", host, channel);
@@ -56,38 +56,38 @@ int main(int argc, char** argv)
         goto exit;
     }
 
-	options.clientID.cstring = "myclientid";
-	len = MQTTSNSerialize_connect(buf, buflen, &options);
+    options.clientID.cstring = "myclientid";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
-	/* wait for connack */
+    /* wait for connack */
     if (MQTTSNPacket_read(buf, buflen, rfcomm_getdata) == MQTTSN_CONNACK)
-	{
-		int connack_rc = -1;
+    {
+        int connack_rc = -1;
 
-		if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
-		{
-			printf("Unable to connect, return code %d\n", connack_rc);
-			goto exit;
-		}
-		else 
-			printf("connected rc %d\n", connack_rc);
-	}
-	else
-		goto exit;
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            printf("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else
+            printf("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
 
-	 
-	/* publish with short name */
-	topic.type = MQTTSN_TOPIC_TYPE_SHORT;
-	memcpy(topic.data.short_name, "tt", 2);
-	len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
-			topic, payload, payloadlen);
+     
+    /* publish with short name */
+    topic.type = MQTTSN_TOPIC_TYPE_SHORT;
+    memcpy(topic.data.short_name, "tt", 2);
+    len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
+            topic, payload, payloadlen);
     rc = rfcomm_sendPacketBuffer(buf, len);
 
-	printf("rc %d from send packet for publish length %d\n", rc, len);
+    printf("rc %d from send packet for publish length %d\n", rc, len);
 
 exit:
     rfcomm_close();
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
I've read though [the contributions requirement](https://github.com/eclipse/paho.mqtt-sn.embedded-c/blob/master/CONTRIBUTING.md), created [an Eclipse account](https://accounts.eclipse.org/users/nlantau) and signed the Eclipse ECA.

During personal research regarding MQTT-SN, I found the code style in some of the example source files to be using a mix of tabs and spaces. I tried to find a coding standard in the project documentation, without any luck. With this pull request, I'm suggesting to use a "4 space standard". If this code style fix is desirable, I'm willing to continue to do similar contributions.

Thanks for your time.
Niklas