### PR TITLE
Prevent buffering of log messages on STDOUT

### DIFF
--- a/MQTTSNGateway/src/mainGateway.cpp
+++ b/MQTTSNGateway/src/mainGateway.cpp
@@ -33,6 +33,9 @@ BrokerSendTask task5(&gateway);
 
 int main(int argc, char** argv)
 {
+    // Prevent buffering of log messages
+    setbuf(stdout, NULL);
+
     try
     {
         gateway.initialize(argc, argv);


### PR DESCRIPTION
When running MQTTSNGateway outside of a terminal (i.e. in a docker container), log messages are buffered by the kernel and are often delayed until a certain amount of data has been logged. This PR disables that buffer.