### PR TITLE
UDP6 Fixes/Improvements

### DIFF
--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -424,7 +424,7 @@ int UDPPort6::broadcast(const uint8_t* buf, uint32_t length)
 
 #ifdef  DEBUG_NW
     char addrBuf[INET6_ADDRSTRLEN];
-    addr->sprint(addrBuf);
+    inet_ntop(AF_INET6, &(dest.sin6_addr.s6_addr), addrBuf, INET6_ADDRSTRLEN);
     D_NWSTACK("sendto %s\n", addrBuf);
 #endif
 

--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -59,6 +59,11 @@ uint16_t SensorNetAddress::getPortNo(void)
     return _IpAddr.sin6_port;
 }
 
+void SensorNetAddress::setPortNo(uint16_t port)
+{
+    _IpAddr.sin6_port = port;
+}
+
 void SensorNetAddress::setAddress(struct sockaddr_in6 *IpAddr)
 {
     memcpy((void*) &_IpAddr, IpAddr, sizeof(_IpAddr));
@@ -388,6 +393,7 @@ int UDPPort6::open(uint16_t uniPortNo, uint16_t multiPortNo, const char *multica
 
     memcpy(&addr6.sin6_addr, &addrm.ipv6mr_multiaddr, sizeof(addrm.ipv6mr_multiaddr));
     _grpAddr.setAddress(&addr6);
+    _grpAddr.setPortNo(multiPortNo);
     return 0;
 }
 

--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.cpp
@@ -402,7 +402,7 @@ int UDPPort6::unicast(const uint8_t* buf, uint32_t length, SensorNetAddress* add
 #ifdef  DEBUG_NW
     char addrBuf[INET6_ADDRSTRLEN];
     addr->sprint(addrBuf);
-    D_NWSTACK("sendto %s\n", addrBuf);
+    D_NWSTACK("sendto %s, port %d\n", addrBuf, dest.sin6_port);
 #endif
 
     int status = ::sendto(_pollfds[0].fd, buf, length, 0, (const sockaddr*) &dest, sizeof(dest));
@@ -425,7 +425,7 @@ int UDPPort6::broadcast(const uint8_t* buf, uint32_t length)
 #ifdef  DEBUG_NW
     char addrBuf[INET6_ADDRSTRLEN];
     inet_ntop(AF_INET6, &(dest.sin6_addr.s6_addr), addrBuf, INET6_ADDRSTRLEN);
-    D_NWSTACK("sendto %s\n", addrBuf);
+    D_NWSTACK("mcast sendto %s, port %d\n", addrBuf, dest.sin6_port);
 #endif
 
     int status = ::sendto(_pollfds[1].fd, buf, length, 0, (const sockaddr*) &dest, sizeof(dest));

--- a/MQTTSNGateway/src/linux/udp6/SensorNetwork.h
+++ b/MQTTSNGateway/src/linux/udp6/SensorNetwork.h
@@ -41,6 +41,7 @@ public:
     int  setAddress(string* data);
     int  setAddress(const char* data);
     uint16_t getPortNo(void);
+    void setPortNo(uint16_t port);
     sockaddr_in6* getIpAddress(void);
     char* getAddress(void);
     bool isMatch(SensorNetAddress* addr);


### PR DESCRIPTION

- Fix DEBUG_NW() error with UDP6 support
- Add destination port to UDP6 address logging
- UDP6 multicast port was never being set

I am a bit unclear about the UDP6 multicast port as it's used for local binding and there seems to be an assumption that the same value should be used for remote port but I don't believe it was ever set.